### PR TITLE
UUID Change

### DIFF
--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -23,10 +23,11 @@ An Agent is a program that will be run on a target system, and will callback to 
 
 ## Agent Requirements
 ### Target Identification Information
-When an Agent calls back to a C2, it is important that the Teamserver is able to identify what machine / target the Agent is running on. IP Addresses alone cannot accurately identify a system, because NAT would cause many systems to appear the same from the C2's perspective. To solve this asset management problem, Arsenal utilizes a combination of the following information:
-  - All MAC Addresses
-  - External IP Address (Collected by the C2)
-When a Session calls back with that criteria, identical to an already existing Target, the Session is associated with the already existing Target. If no Target with the given criteria exists, a new Target is created and is given an automatically generated name. Target naming rules may be created to assign Target names in an automated fashion. The order of the array of MAC Addresses does not matter.
+When an Agent calls back to a C2, it is important that the Teamserver is able to identify what machine / target the Agent is running on. IP Addresses alone cannot accurately identify a system, because NAT would cause many systems to appear the same from the C2's perspective. To solve this asset management problem, Arsenal allows the session to specify a `uuid` field, which is a string that can be set based on your environment that should be unique between targets. Our recommendation is to concatenate the machine-uuid and the mac address of the primary interface. It does not matter what value you use, as long as it is consistent across all agents, and is different between targets. If this criteria changes, a new target will be created on the teamserver automatically. The `MigrateSessions` API endpoint was created in order to attach all session objects from the old target object onto the newly created target object.
+
+When a Session calls back with that criteria, identical to an already existing Target, the Session is associated with the already existing Target. If no Target with the given criteria exists, a new Target is created and is given an automatically generated name. 
+
+_Upcoming Feature_: Target naming rules may be created to assign Target names in an automated fashion.
 
 ### Session ID Tracking
 When an Agent calls back to the C2 for the first time, the C2 must register the newly created Session with the Arsenal Teamserver (If you are unfamiliar, we define a Session as a running instance of an Agent). It uses the Arsenal Teamserver API to do this. Once registered, the C2 is then provided with a Session ID that the Agent must keep track of, and send in every callback request. Without this, the Teamserver will be unable to track which Target a Session belongs to.

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -65,7 +65,7 @@ It is required that Agents support the following action types, or return a speci
 More information on Actions can be found in the database.md documentation file.
 
 ### Fact Collection
-It is recommended that the Agent be capable of collecting facts about a Target system for ease of use. While the only two required facts are the Target's hostname and MAC addresses, many other facts are useful for collection. Please see the database.md documentation's Target section for more information on the default factsets.
+It is recommended that the Agent be capable of collecting facts about a Target system for ease of use.
 
 ## Working with the Arsenal HTTP C2
 
@@ -75,6 +75,7 @@ The existing Arsenal HTTP C2 utilizes JSON as a communication Format. The JSON t
 ```json
 {
   "session_id": "",
+  "uuid": "A target-unique identifier.",
   "config": {
     "interval": 60,
     "interval_delta": 120,
@@ -98,6 +99,7 @@ The existing Arsenal HTTP C2 utilizes JSON as a communication Format. The JSON t
 }
 ```
 * **session_id** - Must be empty string or not present in the initial beacon. The C2 will respond with a session_id that the Agent should keep track of, and send with all future call backs.<br>
+* **uuid** - A unique identifier string that is used to associate the session with a target. It is recommended to concatenate the machine-uuid and the mac address of the machines primary interface, however you may use any identifying criteria that works best for your environment so long as it is consistent across agents, and distinct amongst targets.
 * **config** - This is a dictionary that represents the agent's initial configuration.
 * **facts** - A dictionary containing facts about the target system. The only required fact is "interfaces", which should be provided in the format shown above, however it is recommended that you collect at least the "min" subset on initial beacon (Which can be found under the target section of database.md Documentation). It is also likely that the "hostname" fact will be used for target auto-naming, so it is highly recommended that you collect this fact as well.<br>
 

--- a/teamserver/teamserver/api/session.py
+++ b/teamserver/teamserver/api/session.py
@@ -21,7 +21,7 @@ def create_session(params):
     """
     This API function creates a new session object in the database.
 
-    mac_addrs (required): The list of MAC addresses that the agent gathered from the target <str>
+    target_uuid (required): The unique identifier of the target. <str>
     servers (optional): Which servers the agent will initially be configured with. <[str, str]>
     interval (optional): The interval the agent will initially be configured with. <float>
     interval_delta (optional): The interval delta the agent will initially be
@@ -33,11 +33,11 @@ def create_session(params):
     """
     # Fetch Target, create it automatically if it does not exist
     try:
-        target = Target.get_by_macs(params['mac_addrs'])
+        target = Target.get_by_uuid(params['target_uuid'])
     except DoesNotExist:
         target = Target(
             name=str(uuid4()),
-            mac_addrs=params['mac_addrs'],
+            uuid=params['target_uuid'],
         )
         target.save(force_insert=True)
 

--- a/teamserver/teamserver/api/target.py
+++ b/teamserver/teamserver/api/target.py
@@ -13,16 +13,16 @@ def create_target(params):
     This API function creates a new target object in the database.
 
     name (required, unique): The name given to the target. <str>
-    mac_addrs (required, unique): The MAC addresses used to identify the target. <[str, str]>
+    uuid (required, unique): The unique identifier of the target. <str>
     facts (optional): A dictionary of key,value pairs to store for the target. <dict>
     """
     name = params['name']
-    mac_addrs = params['mac_addrs']
+    uuid = params['uuid']
     facts = params.get('facts', {})
 
     target = Target(
         name=name,
-        mac_addrs=mac_addrs,
+        uuid=uuid,
         facts=facts
     )
     target.save(force_insert=True)

--- a/teamserver/teamserver/models/target.py
+++ b/teamserver/teamserver/models/target.py
@@ -4,7 +4,7 @@
 """
 
 from mongoengine import Document, DynamicEmbeddedDocument
-from mongoengine.fields import StringField, DictField, ListField
+from mongoengine.fields import StringField, DictField
 from mongoengine.fields import EmbeddedDocumentListField
 
 from .session import Session
@@ -40,7 +40,7 @@ class Target(Document):
                 'unique': True
             },
             {
-                'fields': ['mac_addrs'],
+                'fields': ['uuid'],
                 'unique': True
             }
         ]
@@ -52,11 +52,13 @@ class Target(Document):
         max_length=MAX_STR_LEN,
         unique=True)
 
-    mac_addrs = ListField(
-        StringField(required=True, null=False, max_length=20),
-        required=True,
-        null=False,
-        unique=True)
+    #mac_addrs = ListField(
+    #    StringField(required=True, null=False, max_length=20),
+    #    required=True,
+    #    null=False,
+    #    unique=True)
+
+    uuid = StringField(required=True, null=False, max_length=MAX_BIGSTR_LEN, unique=True)
 
     facts = DictField(null=False)
 
@@ -72,11 +74,11 @@ class Target(Document):
         return Target.objects.get(name=name) #pylint: disable=no-member
 
     @staticmethod
-    def get_by_macs(mac_addrs):
+    def get_by_uuid(uuid):
         """
         This method queries for the target object matching the mac_addrs provided.
         """
-        return Target.objects.get(mac_addrs=mac_addrs) #pylint: disable=no-member
+        return Target.objects.get(uuid=uuid) #pylint: disable=no-member
 
     @staticmethod
     def list_targets():
@@ -135,7 +137,7 @@ class Target(Document):
         """
         doc = {
             'name': self.name,
-            'mac_addrs': self.mac_addrs,
+            'uuid': self.uuid,
         }
         if include_status:
             doc['status'] = self.status

--- a/teamserver/tests/api/session_test.py
+++ b/teamserver/tests/api/session_test.py
@@ -26,7 +26,7 @@ class SessionAPITest(BaseTest):
         This test will pass if the session is created.
         """
         target = Database.create_target()
-        data = APIClient.create_session(self.client, target.mac_addrs)
+        data = APIClient.create_session(self.client, target.uuid)
 
         session_id = data['session_id']
         self.assertEqual(False, data['error'])

--- a/teamserver/tests/api/target_test.py
+++ b/teamserver/tests/api/target_test.py
@@ -29,7 +29,7 @@ class TargetAPITest(BaseTest):
         data = APIClient.create_target(
             self.client,
             'TEST Target',
-            ['AA:BB:CC:DD:EE:FF'],
+            'AA:BB:CC:DD:EE:FF',
             {'test_fact': 'hello'})
 
         self.assertEqual(False, data['error'])
@@ -37,7 +37,7 @@ class TargetAPITest(BaseTest):
         target = Database.get_target('TEST Target')
         self.assertIsNotNone(target)
         self.assertEqual(target.name, 'TEST Target')
-        self.assertListEqual(['AA:BB:CC:DD:EE:FF'], target.mac_addrs)
+        self.assertEqual('AA:BB:CC:DD:EE:FF', target.uuid)
         self.assertDictEqual({'test_fact': 'hello'}, target.facts)
 
     def test_get(self):
@@ -49,8 +49,8 @@ class TargetAPITest(BaseTest):
         self.assertEqual(data['error'], False)
         self.assertIsInstance(data['target'], dict)
         self.assertEqual(data['target']['name'], 'GET TEST')
-        self.assertIsInstance(data['target']['mac_addrs'], list)
-        self.assertListEqual(data['target']['mac_addrs'], target.mac_addrs)
+        self.assertIsInstance(data['target']['uuid'], str)
+        self.assertEqual(data['target']['uuid'], target.uuid)
 
     def test_get_params(self):
         """
@@ -62,8 +62,8 @@ class TargetAPITest(BaseTest):
         self.assertEqual(data['error'], False)
         self.assertIsInstance(data['target'], dict)
         self.assertEqual(data['target']['name'], 'PARAMS TEST')
-        self.assertIsInstance(data['target']['mac_addrs'], list)
-        self.assertListEqual(data['target']['mac_addrs'], target.mac_addrs)
+        self.assertIsInstance(data['target']['uuid'], str)
+        self.assertEqual(data['target']['uuid'], target.uuid)
         self.assertIsNotNone(data['target']['actions'])
         self.assertEqual(data['target']['actions'][0]['action_id'], action.action_id)
         with self.assertRaises(KeyError):
@@ -92,7 +92,7 @@ class TargetAPITest(BaseTest):
             'some fact': 55
         }
 
-        target = Database.create_target('FACT TEST', ['AA:BB:CC:DD:EE:FF'], initial_facts)
+        target = Database.create_target('FACT TEST', 'AA:BB:CC:DD:EE:FF', initial_facts)
 
         data = APIClient.set_target_facts(self.client, 'FACT TEST', fact_update)
         self.assertEqual(data['error'], False)

--- a/teamserver/tests/model/target_test.py
+++ b/teamserver/tests/model/target_test.py
@@ -67,47 +67,23 @@ class TargetModelTest(BaseTest):
             target2 = Database.create_target(self.TEST_NAME)
             self.assertEqual(target1.name, target2.name)
 
-    def test_create_dup_macs_fail(self):
+    def test_create_dup_uuid_fail(self):
         """
-        This test will attempt to create targets with the same mac_addrs,
+        This test will attempt to create targets with the same uuids,
         and it will fail as mongo should throw a not unique exception.
         """
 
-        # Single element, same order
+        # basic test
         with self.assertRaises(NotUniqueError):
-            target1 = Database.create_target(None, ['AA:BB:CC:DD:EE:FF'])
-            target2 = Database.create_target(None, ['AA:BB:CC:DD:EE:FF'])
-            self.assertEqual(target1.mac_addrs, target2.mac_addrs)
+            target1 = Database.create_target(None, 'AA:BB:CC:DD:EE:FF')
+            target2 = Database.create_target(None, 'AA:BB:CC:DD:EE:FF')
+            self.assertEqual(target1.uuid, target2.uuid)
 
-        # Multi element, same order
+        # different encoding
         with self.assertRaises(NotUniqueError):
-            target1 = Database.create_target(None, [
-                'AA:BB:CC:DD:EE:FF',
-                'AA:BB:CC:DD:EE:AA'])
-            target2 = Database.create_target(None, [
-                'AA:BB:CC:DD:EE:FF',
-                'AA:BB:CC:DD:EE:AA'])
-            self.assertEqual(target1.mac_addrs, target2.mac_addrs)
-
-        # Multi element, different order
-        with self.assertRaises(NotUniqueError):
-            target1 = Database.create_target(None, [
-                'AA:BB:CC:DD:EE:FF',
-                'AA:BB:CC:DD:EE:AA'])
-            target2 = Database.create_target(None, [
-                'AA:BB:CC:DD:EE:AA',
-                'AA:BB:CC:DD:EE:FF'])
-            self.assertEqual(target1.mac_addrs, target2.mac_addrs)
-
-        # Multi element, different order, different encoding
-        with self.assertRaises(NotUniqueError):
-            target1 = Database.create_target(None, [
-                'AA:BB:CC:DD:EE:FF'.encode('utf-8'),
-                'AA:BB:CC:DD:EE:AA'])
-            target2 = Database.create_target(None, [
-                'AA:BB:CC:DD:EE:AA',
-                'AA:BB:CC:DD:EE:FF'.encode('ascii')])
-            self.assertEqual(target1.mac_addrs, target2.mac_addrs)
+            target1 = Database.create_target(None, 'AA:BB:CC:DD:EE:FF'.encode('utf-8'))
+            target2 = Database.create_target(None, 'AA:BB:CC:DD:EE:FF'.encode('ascii'))
+            self.assertEqual(target1.uuid, target2.uuid)
 
     def test_find_no_name_fail(self):
         """

--- a/teamserver/tests/testutils/api.py
+++ b/teamserver/tests/testutils/api.py
@@ -2,6 +2,7 @@
     This module is used to invoke API functions.
 """
 
+from uuid import uuid4
 from flask import json
 
 class APIClient(object): # pylint: disable=too-many-public-methods
@@ -42,7 +43,7 @@ class APIClient(object): # pylint: disable=too-many-public-methods
     def create_target(
             client,
             name=None,
-            mac_addrs=None,
+            uuid=None,
             facts=None):
         """
         Invoke the CreateTarget API function using the provided client.
@@ -52,7 +53,7 @@ class APIClient(object): # pylint: disable=too-many-public-methods
             data=json.dumps(dict(
                 method='CreateTarget',
                 name=name if name is not None else 'TEST Target',
-                mac_addrs=mac_addrs if mac_addrs else ['AA:BB:CC:DD:EE:FF'],
+                uuid=uuid if uuid else str(uuid4()),
                 facts=facts if facts is not None else {}
             )),
             content_type='application/json',
@@ -151,7 +152,7 @@ class APIClient(object): # pylint: disable=too-many-public-methods
     @staticmethod
     def create_session( # pylint: disable=too-many-arguments
             client,
-            mac_addrs,
+            target_uuid,
             interval=120,
             interval_delta=20,
             servers=None,
@@ -163,7 +164,7 @@ class APIClient(object): # pylint: disable=too-many-public-methods
             '/api',
             data=json.dumps(dict(
                 method='CreateSession',
-                mac_addrs=mac_addrs,
+                target_uuid=target_uuid,
                 servers=servers if servers else ['10.10.10.10', 'https://google.com'],
                 interval=interval,
                 interval_delta=interval_delta,

--- a/teamserver/tests/testutils/database.py
+++ b/teamserver/tests/testutils/database.py
@@ -180,7 +180,7 @@ class Database(object):
     @staticmethod
     def create_target(
             name=None,
-            mac_addrs=None,
+            uuid=None,
             facts=None,
             credentials=None):
         """
@@ -203,10 +203,7 @@ class Database(object):
                     }
                 ]
             },
-            mac_addrs=mac_addrs if mac_addrs is not None else [
-                'AA:BB:CC:DD:EE:FF',
-                str(uuid4())[0:17]
-                ],
+            uuid=uuid if uuid else str(uuid4()),
             credentials=credentials
         )
         target.save(force_insert=True)


### PR DESCRIPTION
Change targets from being uniquely identified by array of mac addrs, to uniquely identified by uuid string. Prevents issues from target having one of the same mac addresses as another target. Introduced `MigrateSessions` API method in order to move existing sessions to a new target and delete the old target.